### PR TITLE
Add app_namespace variable as environment for Slack notification message

### DIFF
--- a/lib/slackistrano/messaging/helpers.rb
+++ b/lib/slackistrano/messaging/helpers.rb
@@ -28,7 +28,7 @@ module Slackistrano
       end
 
       def stage(default = 'an unknown stage')
-        fetch(:app_namespace).presence || fetch(:stage, default)
+        fetch(:app_namespace, '').presence || fetch(:stage, default)
       end
 
       #

--- a/lib/slackistrano/messaging/helpers.rb
+++ b/lib/slackistrano/messaging/helpers.rb
@@ -28,7 +28,7 @@ module Slackistrano
       end
 
       def stage(default = 'an unknown stage')
-        fetch(:stage, default)
+        fetch(:app_namespace).presence || fetch(:stage, default)
       end
 
       #


### PR DESCRIPTION
Set "Environment" variable in Slack message to be "APP_NAMESPACE" to avoid confusing when deploying with RAILS_ENV="production"
Need to update deploy environment files with proper variable ":app_namespace".